### PR TITLE
Improve config checking

### DIFF
--- a/lib/Lightrail.php
+++ b/lib/Lightrail.php
@@ -24,6 +24,9 @@ class Lightrail
         if (!isset(self::$apiKey)) {
             throw new Exceptions\BadParameterException('Lightrail::$apiKey not set.');
         }
+        if (empty(self::$apiKey)) {
+            throw new Exceptions\BadParameterException('Lightrail::$apiKey is empty.');
+        }
     }
 
     public static function checkCardParams($params)

--- a/lib/LightrailShopperTokenFactory.php
+++ b/lib/LightrailShopperTokenFactory.php
@@ -6,8 +6,8 @@ class LightrailShopperTokenFactory
 {
     public static function generate($contact, $validityInSeconds = 43200)
     {
-        if (!isset(Lightrail::$apiKey)) {
-            throw new Exceptions\BadParameterException("Lightrail.apiKey is not set.");
+        if ( ! isset(Lightrail::$apiKey) || empty(Lightrail::$apiKey)) {
+            throw new Exceptions\BadParameterException("Lightrail.apiKey is empty or not set.");
         }
         if (!isset(Lightrail::$sharedSecret)) {
             throw new Exceptions\BadParameterException('Lightrail.sharedSecret is not set.');

--- a/lib/LightrailShopperTokenFactory.php
+++ b/lib/LightrailShopperTokenFactory.php
@@ -9,7 +9,7 @@ class LightrailShopperTokenFactory
         if ( ! isset(Lightrail::$apiKey) || empty(Lightrail::$apiKey)) {
             throw new Exceptions\BadParameterException("Lightrail.apiKey is empty or not set.");
         }
-        if (!isset(Lightrail::$sharedSecret)) {
+        if ( ! isset(Lightrail::$sharedSecret) || empty(Lightrail::$sharedSecret)) {
             throw new Exceptions\BadParameterException('Lightrail.sharedSecret is not set.');
         }
 

--- a/tests/LightrailShopperTokenFactoryTest.php
+++ b/tests/LightrailShopperTokenFactoryTest.php
@@ -70,4 +70,14 @@ class LightrailShopperTokenFactoryTest extends TestCase
         LightrailShopperTokenFactory::generate(array("contactId" => "chauntaktEyeDee"), 600);
     }
 
+    public function testThrowsExceptionIfSharedSecretEmpty()
+    {
+        Lightrail::$apiKey       = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJnIjp7Imd1aSI6Imdvb2V5IiwiZ21pIjoiZ2VybWllIn19.XxOjDsluAw5_hdf5scrLk0UBn8VlhT-3zf5ZeIkEld8";
+        Lightrail::$sharedSecret = "";
+
+        $this->expectException(\Exception::class);
+
+        LightrailShopperTokenFactory::generate(array("contactId" => "chauntaktEyeDee"), 600);
+    }
+
 }

--- a/tests/LightrailShopperTokenFactoryTest.php
+++ b/tests/LightrailShopperTokenFactoryTest.php
@@ -60,4 +60,14 @@ class LightrailShopperTokenFactoryTest extends TestCase
         $this->assertEquals($shopperPayload->iat + 600, $shopperPayload->exp, "exp = iat + 600");
     }
 
+    public function testThrowsExceptionIfApiKeyEmpty()
+    {
+        Lightrail::$apiKey       = "";
+        Lightrail::$sharedSecret = "secret";
+
+        $this->expectException(\Exception::class);
+
+        LightrailShopperTokenFactory::generate(array("contactId" => "chauntaktEyeDee"), 600);
+    }
+
 }


### PR DESCRIPTION
Previously, the library would not complain if the API key or shared secret was set to an empty string. Now it does. 